### PR TITLE
Fix warnings to ensure moon check functionality

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -6,7 +6,10 @@ This implementation provides the basic functionality of a trie, including insert
 # Usage
 
 ```moonbit
-typealias @trie.Trie
+///|
+using @trie {type Trie}
+
+///|
 test {
   let trie = Trie::of([("--search", "search"), ("--switch", "switch")])
   inspect(trie.lookup("--search"), content="Some(\"search\")")

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -3,22 +3,22 @@ package "Yoorkin/trie"
 
 // Values
 #deprecated
-fn[A] empty() -> Trie[A]
+pub fn[A] empty() -> Trie[A]
 
 // Errors
 
 // Types and methods
+#alias(T)
 type Trie[A]
-fn[A] Trie::add(Self[A], String, A) -> Self[A]
-fn[A] Trie::empty() -> Self[A]
-fn[A] Trie::from_array(Array[(String, A)]) -> Self[A]
+pub fn[A] Trie::add(Self[A], String, A) -> Self[A]
+pub fn[A] Trie::empty() -> Self[A]
+pub fn[A] Trie::from_array(Array[(String, A)]) -> Self[A]
 #deprecated
-fn[A] Trie::insert(Self[A], String, A) -> Self[A]
-fn[A] Trie::lookup(Self[A], String) -> A?
-fn[A] Trie::of(FixedArray[(String, A)]) -> Self[A]
+pub fn[A] Trie::insert(Self[A], String, A) -> Self[A]
+pub fn[A] Trie::lookup(Self[A], String) -> A?
+pub fn[A] Trie::of(FixedArray[(String, A)]) -> Self[A]
 
 // Type aliases
-pub typealias Trie as T
 
 // Traits
 

--- a/trie.mbt
+++ b/trie.mbt
@@ -1,11 +1,9 @@
 ///|
+#alias(T)
 struct Trie[A] {
   value : A?
   forks : @immut/sorted_map.SortedMap[Char, Trie[A]]
 }
-
-///|
-pub typealias Trie as T
 
 ///|
 pub fn[A] Trie::lookup(self : Self[A], path : String) -> A? {
@@ -29,7 +27,7 @@ pub fn[A] Trie::insert(self : Self[A], path : String, value : A) -> Trie[A] {
 pub fn[A] Trie::add(self : Self[A], path : String, value : A) -> Trie[A] {
   fn aux(xs, trie) {
     match xs {
-      ([] : @string.View) => Trie::{ ..trie, value: Some(value) }
+      ([] : StringView) => Trie::{ ..trie, value: Some(value) }
       [x, .. xs] => {
         let subtree = trie.forks
           .get(x)


### PR DESCRIPTION
## Summary

This PR addresses warnings in the codebase with minimal changes to ensure `moon check` works properly. The changes focus on eliminating warnings while maintaining existing functionality.

## Changes Made

- **README.mbt.md**: Updated documentation to reflect current state
- **pkg.generated.mbti**: Modified type definitions to resolve warnings (16 lines changed)
- **trie.mbt**: Updated implementation to address warning issues (6 lines changed)

## Rationale

The primary goal is to eliminate warnings that prevent `moon check` from working correctly. These changes are intentionally minimal to avoid introducing unnecessary modifications while ensuring the package passes validation checks.

## Implementation Details

- Total of 14 insertions and 13 deletions across 3 files
- Changes focus on type definitions and implementation details that generate warnings
- No functional changes to the core trie implementation
- Maintains backward compatibility

## Verification

The changes should enable `moon check` to run without warnings. If `moon test` also works as a result, that would be beneficial, but the primary requirement is ensuring `moon check` functionality.