### PR TITLE
Fix nightly warning regressions

### DIFF
--- a/moon.pkg
+++ b/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/core/immut/sorted_map" @immut/sorted_map,
+}

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -1,8 +1,0 @@
-{
-  "import": [
-    {
-      "path": "moonbitlang/core/immut/sorted_map",
-      "alias": "immut/sorted_map"
-    }
-  ]
-}


### PR DESCRIPTION
Automated cleanup for nightly regressions: run moon fmt/info/check and fix deprecated/deprecated_syntax warnings.