### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -12,9 +12,9 @@ using @trie {type Trie}
 ///|
 test {
   let trie = Trie::of([("--search", "search"), ("--switch", "switch")])
-  inspect(trie.lookup("--search"), content="Some(\"search\")")
+  @debug.debug_inspect(trie.lookup("--search"), content="Some(\"search\")")
   let trie = trie.add("-s", "s")
-  inspect(trie.lookup("-s"), content="Some(\"s\")")
-  inspect(trie.lookup("--switch"), content="Some(\"switch\")")
+  @debug.debug_inspect(trie.lookup("-s"), content="Some(\"s\")")
+  @debug.debug_inspect(trie.lookup("--switch"), content="Some(\"switch\")")
 }
 ```

--- a/moon.pkg
+++ b/moon.pkg
@@ -1,3 +1,7 @@
 import {
   "moonbitlang/core/immut/sorted_map" @immut/sorted_map,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "test"

--- a/trie_test.mbt
+++ b/trie_test.mbt
@@ -5,7 +5,7 @@ test {
     ("-s", "s"),
     ("--switch", "switch"),
   ])
-  assert_eq(trie.lookup("--search"), Some("search"))
-  assert_eq(trie.lookup("-s"), Some("s"))
-  assert_eq(trie.lookup("--switch"), Some("switch"))
+  @debug.assert_eq(trie.lookup("--search"), Some("search"))
+  @debug.assert_eq(trie.lookup("-s"), Some("s"))
+  @debug.assert_eq(trie.lookup("--switch"), Some("switch"))
 }


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
